### PR TITLE
P Value Efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following fields are optional:
  - `analysis_mask`: A mask to be applied during analysis.
  - `OutputCovB`: If set to `True` this will output between beta covariance maps. For studies with a large number of paramters this may not be desirable as, for example, 30 analysis paramters will create 30x30=900 between beta covariance maps. By default this is set to `True`.
  - `data_mask_thresh`: Any voxel with value below this threshold will be treated as missing data. (By default, no such thresholding  is done, i.e. `data_mask_thresh` is essentially -infinity). 
+ - `minlog`: Any `-inf` values in the `-log10(p)` maps will be converted to the value of `minlog`. Currently the default is set to a default of `-323.3062153431158` as this is the most negative value which was seen during testing before `-inf` was encountered (see [this thread](https://github.com/TomMaullin/BLM/issues/76) for more details).
 
 
  

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following fields are optional:
  - `analysis_mask`: A mask to be applied during analysis.
  - `OutputCovB`: If set to `True` this will output between beta covariance maps. For studies with a large number of paramters this may not be desirable as, for example, 30 analysis paramters will create 30x30=900 between beta covariance maps. By default this is set to `True`.
  - `data_mask_thresh`: Any voxel with value below this threshold will be treated as missing data. (By default, no such thresholding  is done, i.e. `data_mask_thresh` is essentially -infinity). 
- - `minlog`: Any `-inf` values in the `-log10(p)` maps will be converted to the value of `minlog`. Currently the default is set to a default of `-323.3062153431158` as this is the most negative value which was seen during testing before `-inf` was encountered (see [this thread](https://github.com/TomMaullin/BLM/issues/76) for more details).
+ - `minlog`: Any `-inf` values in the `-log10(p)` maps will be converted to the value of `minlog`. Currently, a default value of `-323.3062153431158` is used as this is the most negative value which was seen during testing before `-inf` was encountered (see [this thread](https://github.com/TomMaullin/BLM/issues/76) for more details).
 
 
  

--- a/lib/blm_concat.py
+++ b/lib/blm_concat.py
@@ -626,18 +626,16 @@ def main(*args):
 
             # Work out p for this contrast
             if n_v_i:
-                if tStatc_i > 0:
-                    pc_i = -np.log10(stats.t.cdf(-tStatc_i, df_i))
-                else:
-                    pc_i = -np.log10(1-stats.t.cdf(tStatc_i, df_i))
+                # Do this seperately for >0 and <0 to avoid underflow
+                pc_i = np.zeros(np.shape(tStatc_i))
+                pc_i[tStatc_i < 0] = -np.log10(1-stats.t.cdf(tStatc_i[tStatc_i < 0], df_i))
+                pc_i[tStatc_i >= 0] = -np.log10(stats.t.cdf(-tStatc_i[tStatc_i >= 0], df_i))
+
                 pc[I_inds] = pc_i
 
             if n_v_r:
+                # Do this seperately for >0 and <0 to avoid underflow
                 pc_r = np.zeros(np.shape(tStatc_r))
-                print(np.shape(tStatc_r))
-                print(np.shape(df_r))
-                print(np.shape(tStatc_r < 0))
-                print(np.shape(tStatc_r[tStatc_r < 0]))
                 pc_r[tStatc_r < 0] = -np.log10(1-stats.t.cdf(tStatc_r[tStatc_r < 0], df_r[tStatc_r < 0]))
                 pc_r[tStatc_r >= 0] = -np.log10(stats.t.cdf(-tStatc_r[tStatc_r >= 0], df_r[tStatc_r >= 0]))
 

--- a/lib/blm_concat.py
+++ b/lib/blm_concat.py
@@ -631,6 +631,12 @@ def main(*args):
                 pc_i[tStatc_i < 0] = -np.log10(1-stats.t.cdf(tStatc_i[tStatc_i < 0], df_i))
                 pc_i[tStatc_i >= 0] = -np.log10(stats.t.cdf(-tStatc_i[tStatc_i >= 0], df_i))
 
+                # Remove infs
+                if "minlog" in inputs:
+                    pc_i[np.logical_and(np.isinf(pc_i), pc_i<0)]=inputs['minlog']
+                else:
+                    pc_i[np.logical_and(np.isinf(pc_i), pc_i<0)]=-323.3062153431158
+
                 pc[I_inds] = pc_i
 
             if n_v_r:
@@ -638,6 +644,12 @@ def main(*args):
                 pc_r = np.zeros(np.shape(tStatc_r))
                 pc_r[tStatc_r < 0] = -np.log10(1-stats.t.cdf(tStatc_r[tStatc_r < 0], df_r[tStatc_r < 0]))
                 pc_r[tStatc_r >= 0] = -np.log10(stats.t.cdf(-tStatc_r[tStatc_r >= 0], df_r[tStatc_r >= 0]))
+
+                # Remove infs
+                if "minlog" in inputs:
+                    pc_r[np.logical_and(np.isinf(pc_r), pc_r<0)]=inputs['minlog']
+                else:
+                    pc_r[np.logical_and(np.isinf(pc_r), pc_r<0)]=-323.3062153431158
 
                 pc[R_inds] = pc_r
 

--- a/lib/blm_concat.py
+++ b/lib/blm_concat.py
@@ -757,10 +757,24 @@ def main(*args):
             # Work out p for this contrast
             if n_v_i:
                 pc_i = -np.log10(1-stats.f.cdf(fStatc_i, q, df_i))
+
+                # Remove infs
+                if "minlog" in inputs:
+                    pc_i[np.logical_and(np.isinf(pc_i), pc_i<0)]=inputs['minlog']
+                else:
+                    pc_i[np.logical_and(np.isinf(pc_i), pc_i<0)]=-323.3062153431158
+
                 pc[I_inds] = pc_i
 
             if n_v_r:
                 pc_r = -np.log10(1-stats.f.cdf(fStatc_r, q, df_r))
+
+                # Remove infs
+                if "minlog" in inputs:
+                    pc_r[np.logical_and(np.isinf(pc_r), pc_r<0)]=inputs['minlog']
+                else:
+                    pc_r[np.logical_and(np.isinf(pc_r), pc_r<0)]=-323.3062153431158
+
                 pc[R_inds] = pc_r
 
             p_f[:,:,:,current_n_cf] = pc.reshape(

--- a/lib/blm_concat.py
+++ b/lib/blm_concat.py
@@ -626,11 +626,17 @@ def main(*args):
 
             # Work out p for this contrast
             if n_v_i:
-                pc_i = -np.log10(1-stats.t.cdf(tStatc_i, df_i))
+                if tStatc_i > 0:
+                    pc_i = -np.log10(stats.t.cdf(-tStatc_i, df_i))
+                else:
+                    pc_i = -np.log10(1-stats.t.cdf(tStatc_i, df_i))
                 pc[I_inds] = pc_i
 
             if n_v_r:
-                pc_r = -np.log10(1-stats.t.cdf(tStatc_r, df_r))
+                pc_r = np.zeros(np.shape(tStatc_r))
+                pc_r[tStatc_r < 0] = -np.log10(1-stats.t.cdf(tStatc_r[tStatc_r < 0], df_r[tStatc_r < 0]))
+                pc_r[tStatc_r > 0] = -np.log10(stats.t.cdf(-tStatc_r[tStatc_r > 0], df_r[tStatc_r > 0]))
+
                 pc[R_inds] = pc_r
 
             p_t[:,:,:,current_n_ct] = pc.reshape(

--- a/lib/blm_concat.py
+++ b/lib/blm_concat.py
@@ -634,8 +634,12 @@ def main(*args):
 
             if n_v_r:
                 pc_r = np.zeros(np.shape(tStatc_r))
+                print(np.shape(tStatc_r))
+                print(np.shape(df_r))
+                print(np.shape(tStatc_r < 0))
+                print(np.shape(tStatc_r[tStatc_r < 0]))
                 pc_r[tStatc_r < 0] = -np.log10(1-stats.t.cdf(tStatc_r[tStatc_r < 0], df_r[tStatc_r < 0]))
-                pc_r[tStatc_r > 0] = -np.log10(stats.t.cdf(-tStatc_r[tStatc_r > 0], df_r[tStatc_r > 0]))
+                pc_r[tStatc_r >= 0] = -np.log10(stats.t.cdf(-tStatc_r[tStatc_r >= 0], df_r[tStatc_r >= 0]))
 
                 pc[R_inds] = pc_r
 

--- a/lib/blm_setup.py
+++ b/lib/blm_setup.py
@@ -94,8 +94,7 @@ def main(*args):
         with open(ipath, 'w') as outfile:
             yaml.dump(inputs, outfile, default_flow_style=False)
 
-    # Change paths to absoluate if they aren't already
-    
+    # Change paths to absoluate if they aren't already    
     if 'MAXMEM' in inputs:
         MAXMEM = eval(inputs['MAXMEM'])
     else:


### PR DESCRIPTION
This PR addresses issue #76 by doing the following:

 - Treating each tail of the T distribution separately as described in the thread for PR #76 
 - Replacing any remaining `-inf` values in `-log10(p)` maps with `-323.3062153431158`, again as discussed in PR #76.
 - The `README.md` has been updated to include a backdoor option to allow the changing of the constant value in the previous bullet point.